### PR TITLE
256 color, 1 per host

### DIFF
--- a/sshp.js
+++ b/sshp.js
@@ -329,6 +329,7 @@ function color256(n) {
 }
 
 function make_colorizor(seed) {
+  // 193 is the nearest prime to 256-64=192
   var cycle = z_p_star((seed + 1) % 193, 193);
   var host_colors = {};
   return function(host) {


### PR DESCRIPTION
You can customize the `130` seed to change the default color sequence.

It doesn't actually cycle through all of the colors, since some of them are pretty illegible.
