### PR TITLE
Disable keyboard input

### DIFF
--- a/sshp.js
+++ b/sshp.js
@@ -197,6 +197,7 @@ var host_color = (colors.mode === 'none' || process.env.SSHP_NO_RAINBOW) ? cyan_
 
 // construct the SSH command
 var sshcommand = ['ssh'];
+sshcommand.push('-n');
 if (quiet)
   sshcommand.push('-q');
 if (port)


### PR DESCRIPTION
From what I understand, it's impossible to send it to the right connection, and generally just causes things to get stuck (especially when using joining outputs: you would not even see the input prompt).